### PR TITLE
feature: add OPC UA client and mocked client

### DIFF
--- a/opcua/__init__.py
+++ b/opcua/__init__.py
@@ -1,0 +1,6 @@
+__all__ = [
+    'types',
+    'client',
+    'objects',
+    'mock'
+]

--- a/opcua/client.py
+++ b/opcua/client.py
@@ -1,0 +1,30 @@
+from asyncua import Client, ua
+
+from opcua.types import BaseOpcuaClient, OpcuaValue
+
+
+class OpcuaClient(BaseOpcuaClient):
+
+    def __init__(self, url: str):
+        self.client = Client(url=url)
+
+    def __aenter__(self):
+        self.client.connect()
+
+    def __aexit__(self, exc_type, exc_val, exc_tb):
+        self.client.disconnect()
+
+    async def connect(self) -> None:
+        await self.client.connect()
+
+    async def disconnect(self) -> None:
+        await self.client.disconnect()
+
+    async def get(self, node_id: str, default=None) -> OpcuaValue:
+        node = self.client.get_node(node_id)
+        return await node.read_value()
+
+    async def set(self, node_id: str, value: OpcuaValue) -> None:
+        node = self.client.get_node(node_id)
+        data_type = await node.read_data_type_as_variant_type()
+        await node.write_value(ua.DataValue(ua.Variant(value, data_type)))

--- a/opcua/mock.py
+++ b/opcua/mock.py
@@ -1,0 +1,25 @@
+import asyncio
+
+from opcua.client import BaseOpcuaClient
+from opcua.types import OpcuaValue
+
+
+class MockOpcuaClient(BaseOpcuaClient):
+
+    def __init__(self, delay: float = 0.1):
+        self.table = {}
+        self.delay: float = delay
+
+    async def connect(self) -> None:
+        await asyncio.sleep(self.delay)
+
+    async def disconnect(self) -> None:
+        await asyncio.sleep(self.delay)
+
+    async def get(self, node_id: str, default=None) -> OpcuaValue:
+        await asyncio.sleep(self.delay)
+        return self.table.setdefault(node_id, default)
+
+    async def set(self, node_id: str, value: OpcuaValue) -> None:
+        await asyncio.sleep(self.delay)
+        self.table[node_id] = value

--- a/opcua/objects.py
+++ b/opcua/objects.py
@@ -1,0 +1,34 @@
+from opcua.types import OpcuaObject, AsyncMutator, OpcuaVariable
+
+
+class OpcuaPrinter(OpcuaObject):
+    program_id: AsyncMutator[int] = OpcuaVariable(name='progID', default=0)
+    start: AsyncMutator[bool] = OpcuaVariable(name='start', default=False)
+
+    part_removed: AsyncMutator[bool] = OpcuaVariable(name='Pc_PartRemoved', default=False)
+    bed_cleaned: AsyncMutator[bool] = OpcuaVariable(name='Pc_BedCleaned', default=False)
+
+    file: AsyncMutator[str] = OpcuaVariable(name='Pc_File', default='Default')
+
+    jog_x: AsyncMutator[float] = OpcuaVariable(name='Pc_JogX', default=0)
+    jog_y: AsyncMutator[float] = OpcuaVariable(name='Pc_JogY', default=0)
+    jog_z: AsyncMutator[float] = OpcuaVariable(name='Pc_JogZ', default=0)
+
+    ready: AsyncMutator[bool] = OpcuaVariable(name='Pf_Ready', default=False)
+    end: AsyncMutator[bool] = OpcuaVariable(name='Pf_End', default=True)
+
+    current_state: AsyncMutator[str] = OpcuaVariable(name='Pd_State', default='Error')
+
+    bed_current_temperature: AsyncMutator[float] = OpcuaVariable(name='Pd_tBedReal', default=0)
+    bed_target_temperature: AsyncMutator[float] = OpcuaVariable(name='Pd_tBedTarget', default=0)
+
+    nozzle_current_temperature: AsyncMutator[float] = OpcuaVariable(name='Pd_tNozReal', default=0)
+    nozzle_target_temperature: AsyncMutator[float] = OpcuaVariable(name='Pd_tNozTarget', default=0)
+
+    job_file: AsyncMutator[str] = OpcuaVariable(name='Pd_JobFile', default='Default')
+    job_progress: AsyncMutator[float] = OpcuaVariable(name='Pd_JobProgress', default=0)
+    job_time: AsyncMutator[float] = OpcuaVariable(name='Pd_JobTime', default=0)
+    job_time_left: AsyncMutator[float] = OpcuaVariable(name='Pd_JobTimeLeft', default=0)
+    job_time_estimate: AsyncMutator[float] = OpcuaVariable(name='Pd_JobTimeEst', default=0)
+
+    api_resp: AsyncMutator[str] = OpcuaVariable(name='Pd_APIResp', default='default')

--- a/opcua/tests.py
+++ b/opcua/tests.py
@@ -1,0 +1,121 @@
+import asyncio
+import unittest
+from datetime import datetime
+
+from opcua.mock import MockOpcuaClient
+from opcua.types import OpcuaObject, OpcuaVariable
+
+
+class Foo(OpcuaObject):
+    name = OpcuaVariable(name='Foo_Name', default='default')
+
+
+class MockClientGetObjectTest(unittest.TestCase):
+    def test_context_variables(self):
+        client = MockOpcuaClient()
+        obj = client.get_object(Foo, namespace_idx=3)
+
+        self.assertEqual(obj.__client__, client)
+        self.assertEqual(obj.__ns__, 3)
+
+
+class MockClientQueryTest(unittest.IsolatedAsyncioTestCase):
+
+    async def test_get_default(self):
+        client = MockOpcuaClient()
+        namespace = 'ns=3;s=Foo_Name'
+        value = await client.get(namespace, default='default')
+
+        self.assertEqual(value, 'default')
+        self.assertEqual(client.table[namespace], 'default')
+
+    async def test_get(self):
+        client = MockOpcuaClient()
+        namespace = 'ns=3;s=Foo_Name'
+        client.table[namespace] = 'foobar'
+
+        value = await client.get(namespace)
+
+        self.assertEqual(value, 'foobar')
+
+    async def test_set(self):
+        client = MockOpcuaClient()
+        namespace = 'ns=3;s=Foo_Name'
+
+        await client.set(namespace, 'foobar')
+
+        self.assertEqual(client.table[namespace], 'foobar')
+
+
+class MockOpcuaObjectTest(unittest.IsolatedAsyncioTestCase):
+
+    async def test_get_default(self):
+        client = MockOpcuaClient()
+        obj = client.get_object(Foo, namespace_idx=3)
+
+        value = await obj.name.get()
+
+        self.assertEqual(value, 'default')
+        self.assertEqual(client.table['ns=3;s=Foo_Name'], 'default')
+
+    async def test_get(self):
+        client = MockOpcuaClient()
+        obj = client.get_object(Foo, namespace_idx=3)
+
+        client.table['ns=3;s=Foo_Name'] = 'foobar'
+
+        value = await obj.name.get()
+
+        self.assertEqual(value, 'foobar')
+
+    async def test_set(self):
+        client = MockOpcuaClient()
+        obj = client.get_object(Foo, namespace_idx=3)
+
+        client.table['ns=3;s=Foo_Name'] = 'foobar'
+
+        value = await obj.name.get()
+
+        self.assertEqual(value, 'foobar')
+
+
+class MultipleMockOpcuaObjectTest(unittest.IsolatedAsyncioTestCase):
+
+    async def test_mutation(self):
+        client = MockOpcuaClient()
+        foo1 = client.get_object(Foo, namespace_idx=1)
+        foo2 = client.get_object(Foo, namespace_idx=2)
+
+        await foo1.name.set('foo1')
+        await foo2.name.set('foo2')
+
+        name1 = await foo1.name.get()
+        name2 = await foo2.name.get()
+
+        self.assertEqual(name1, 'foo1')
+        self.assertEqual(name2, 'foo2')
+
+    async def test_concurrent_set(self):
+        client = MockOpcuaClient(delay=0.25)
+        foo1 = client.get_object(Foo, namespace_idx=1)
+        foo2 = client.get_object(Foo, namespace_idx=2)
+
+        start_time = datetime.now()
+
+        async def update_name(foo: Foo, name: str):
+            await foo.name.set(name)  # 0.25s
+            return await foo.name.get()  # 0.25s
+
+        async with asyncio.TaskGroup() as group:
+            task1 = group.create_task(update_name(foo1, 'foo1'))
+            task2 = group.create_task(update_name(foo2, 'foo2'))
+
+        sec_used = (datetime.now() - start_time).total_seconds()
+
+        self.assertEqual(task1.result(), 'foo1')
+        self.assertEqual(task2.result(), 'foo2')
+        self.assertLess(sec_used, 0.6)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/opcua/types.py
+++ b/opcua/types.py
@@ -1,0 +1,60 @@
+from abc import ABC, abstractmethod
+from typing import TypeVar, Optional, Type, Generic
+
+OpcuaValue = TypeVar('OpcuaValue', int, str, float, bool)
+
+
+class OpcuaObject:
+    __client__: 'BaseOpcuaClient'
+    __ns__: int
+
+
+class BaseOpcuaClient(ABC):
+
+    @abstractmethod
+    async def connect(self) -> None:
+        pass
+
+    @abstractmethod
+    async def disconnect(self) -> None:
+        pass
+
+    @abstractmethod
+    async def get(self, node_id: str, default: Optional[OpcuaValue] = None) -> OpcuaValue:
+        pass
+
+    @abstractmethod
+    async def set(self, node_id: str, value: OpcuaValue) -> None:
+        pass
+
+    ObjectNode = TypeVar('ObjectNode', bound=OpcuaObject)
+
+    def get_object(self, obj_type: Type[ObjectNode], namespace_idx: int) -> ObjectNode:
+        obj = obj_type()
+        obj.__client__ = self
+        obj.__ns__ = namespace_idx
+        return obj
+
+
+class AsyncMutator(Generic[OpcuaValue]):
+
+    def __init__(self, name: str, storage: BaseOpcuaClient, ns: int, default: Optional[OpcuaValue] = None):
+        self.storage: BaseOpcuaClient = storage
+        self.node_id: str = f'ns={ns};s={name}'
+        self.default: Optional[OpcuaValue] = default
+
+    async def get(self) -> OpcuaValue:
+        return await self.storage.get(self.node_id, self.default)
+
+    async def set(self, value: OpcuaValue) -> None:
+        await self.storage.set(self.node_id, value)
+
+
+class OpcuaVariable(Generic[OpcuaValue]):
+
+    def __init__(self, name: str, default: Optional[OpcuaValue] = None):
+        self.name: str = name
+        self.default: Optional[OpcuaValue] = default
+
+    def __get__(self, instance: OpcuaObject, owner) -> AsyncMutator:
+        return AsyncMutator(name=self.name, storage=instance.__client__, ns=instance.__ns__, default=self.default)


### PR DESCRIPTION

All subclasses of `OpcuaObject` represents an object node in OPC UA server. `OpcuaObject` only contains variable node definitions and thus is easy to maintain.

The `BaseOpcuaClient` class defines how the client connects to the server and reads/writes data. The client can create an `OpcuaObject` instance given the `OpcuaObject` class and its namespace index in the server. We can use the returned `OpcuaObject` instance to access and modify data on the server:

```python
client = OpcuaClient()
opcua_printer = client.get_object(OpcuaPrinter, namespace_idx=1)

program_id = await opcua_printer.program_id.get()
await opcua_printer.program_id.set(program_id + 1)
```

Implementation details: 
* `BaseOpcuaClient::get_object` creates an `OpcuaObject` instance and set **context info** of the object: namespace index and the client itself
* variable node definitions in `OpcuaObject` are [field descriptors](https://docs.python.org/3/howto/descriptor.html), which returns the actual mutator (async getter and setter) of the object node at runtime
* mutators are returned because `await field = value` is invalid in Python, only `await expression` is allowed

The unit test code shows how to:
* define another OPC UA object node
* use a mocked client in development or other test cases
* query multiple nodes concurrently

