### PR TITLE
refactor opcuax tests

### DIFF
--- a/tests/opcuax/mock/conftest.py
+++ b/tests/opcuax/mock/conftest.py
@@ -1,6 +1,5 @@
-import asyncio
-
 import pytest
+import pytest_asyncio
 from _pytest.fixtures import FixtureRequest
 
 from opcuax.mock import MockOpcuaClient
@@ -11,30 +10,27 @@ class Printer(OpcuaObject):
     name = OpcuaVariable(name="Printer_Name", default="unknown")
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def opcua_client(request: FixtureRequest) -> MockOpcuaClient:
     client = MockOpcuaClient()
     await client.connect()
-    request.addfinalizer(lambda: asyncio.run(client.disconnect()))
-    return client
+    yield client
+    await client.disconnect()
 
 
 @pytest.fixture
-async def opcua_printer1(opcua_client) -> Printer:
-    client = await opcua_client
-    return client.get_object(Printer, namespace_idx=1)
+def opcua_printer1(opcua_client) -> Printer:
+    return opcua_client.get_object(Printer, namespace_idx=1)
 
 
 @pytest.fixture
-async def opcua_printer2(opcua_client) -> Printer:
-    client = await opcua_client
-    return client.get_object(Printer, namespace_idx=2)
+def opcua_printer2(opcua_client) -> Printer:
+    return opcua_client.get_object(Printer, namespace_idx=2)
 
 
 @pytest.fixture
-async def opcua_printers(opcua_client) -> list[Printer]:
-    client = await opcua_client
+def opcua_printers(opcua_client) -> list[Printer]:
     return [
-        client.get_object(Printer, namespace_idx=1),
-        client.get_object(Printer, namespace_idx=2),
+        opcua_client.get_object(Printer, namespace_idx=1),
+        opcua_client.get_object(Printer, namespace_idx=2),
     ]

--- a/tests/opcuax/mock/test_client.py
+++ b/tests/opcuax/mock/test_client.py
@@ -5,7 +5,7 @@ from opcuax.types import BaseOpcuaClient
 
 @pytest.mark.asyncio
 async def test_context_variables_are_set(opcua_printer1):
-    printer = await opcua_printer1
+    printer = opcua_printer1
     assert printer.__client__ is not None
     assert isinstance(printer.__client__, BaseOpcuaClient)
     assert printer.__ns__ == 1
@@ -13,35 +13,30 @@ async def test_context_variables_are_set(opcua_printer1):
 
 @pytest.mark.asyncio
 async def test_get_default_value(opcua_client):
-    client = await opcua_client
     namespace = "ns=1;s=Printer_Name"
     default_value = "unknown"
 
-    value = await client.get(namespace, default=default_value)
+    value = await opcua_client.get(namespace, default=default_value)
 
     assert value == default_value
-    assert client.table[namespace] == default_value
+    assert opcua_client.table[namespace] == default_value
 
 
 @pytest.mark.asyncio
 async def test_get(opcua_client):
-    client = await opcua_client
-
     namespace = "ns=1;s=Printer_Name"
     value = "foobar"
 
-    client.table[namespace] = value
+    opcua_client.table[namespace] = value
 
-    assert (await client.get(namespace)) == value
+    assert (await opcua_client.get(namespace)) == value
 
 
 @pytest.mark.asyncio
 async def test_set(opcua_client):
-    client = await opcua_client
-
     namespace = "ns=1;s=Printer_Name"
     value = "foobar"
 
-    await client.set(namespace, value)
+    await opcua_client.set(namespace, value)
 
-    assert client.table[namespace] == value
+    assert opcua_client.table[namespace] == value

--- a/tests/opcuax/mock/test_object.py
+++ b/tests/opcuax/mock/test_object.py
@@ -9,10 +9,8 @@ from tests.opcuax.mock.conftest import Printer
 
 @pytest.mark.asyncio
 async def test_get_default(opcua_printer1):
-    obj = await opcua_printer1
-
-    value = await obj.name.get()
-    client_value = await obj.__client__.get("ns=1;s=Printer_Name")
+    value = await opcua_printer1.name.get()
+    client_value = await opcua_printer1.__client__.get("ns=1;s=Printer_Name")
 
     assert value == "unknown"
     assert client_value == "unknown"
@@ -20,32 +18,27 @@ async def test_get_default(opcua_printer1):
 
 @pytest.mark.asyncio
 async def test_get(opcua_printer1):
-    obj = await opcua_printer1
-
     value = "foobar"
-    await obj.__client__.set("ns=1;s=Printer_Name", value)
+    await opcua_printer1.__client__.set("ns=1;s=Printer_Name", value)
 
-    actual = await obj.name.get()
+    actual = await opcua_printer1.name.get()
 
     assert actual == value
 
 
 @pytest.mark.asyncio
 async def test_set(opcua_printer1):
-    obj = await opcua_printer1
-
     value = "foobar"
-    await obj.name.set(value)
+    await opcua_printer1.name.set(value)
 
-    actual = await obj.__client__.get("ns=1;s=Printer_Name")
+    actual = await opcua_printer1.__client__.get("ns=1;s=Printer_Name")
 
     assert actual == value
 
 
 @pytest.mark.asyncio
 async def test_mutation(opcua_printers):
-    printers = await opcua_printers
-    [printer1, printer2] = printers
+    [printer1, printer2] = opcua_printers
 
     await printer1.name.set("foo")
     await printer2.name.set("bar")


### PR DESCRIPTION
* replace `addfinalizer()` with `yield` 
* use `@pytest_asyncio.fixture` for async fixtures