### PR TITLE
fix: should create `OctoRestClient` in async functions

### DIFF
--- a/src/config/loader.py
+++ b/src/config/loader.py
@@ -25,24 +25,26 @@ def is_mocking(url: str):
     return url.startswith("mock")
 
 
-async def make_opcua_client(url: str) -> OpcuaClient:
+def make_opcua_client(url: str) -> OpcuaClient:
     if is_mocking(url):
         return MockOpcuaClient(url=url)
     else:
-        # OpcuaClient::client must be initialized in an async function
         return OpcuaClient(url=url)
 
 
-def make_octo_client(url: str, api_key: str) -> BaseOctoClient:
+async def make_octo_client(url: str, api_key: str) -> BaseOctoClient:
     if is_mocking(url):
         return MockOctoClient(url=url, api_key=api_key)
     else:
+        # aio.ClientSession must be initialized in an async function
         return OctoRestClient(url=url, api_key=api_key)
 
 
-def make_printer_worker(printer: Printer, db: Database, opcua_client: OpcuaClient):
+async def make_printer_worker(
+    printer: Printer, db: Database, opcua_client: OpcuaClient
+):
     opcua_printer = opcua_client.get_object(OpcuaPrinter, ns=printer.opcua_ns)
-    octo_printer = make_octo_client(printer.octo_url, printer.octo_api_key)
+    octo_printer = await make_octo_client(printer.octo_url, printer.octo_api_key)
 
     return PrinterWorker(
         session=db.open_session(), opcua_printer=opcua_printer, octo=octo_printer
@@ -55,8 +57,8 @@ async def load_app_context(env_filepath: str = ".env") -> AppContext:
     db = await load_db(config.db_url)
     session = db.open_session()
     printers = await session.all(Printer)
-    opcua_client = await make_opcua_client(url=config.opcua_server_url)
-    workers = [make_printer_worker(p, db, opcua_client) for p in printers]
+    opcua_client = make_opcua_client(url=config.opcua_server_url)
+    workers = [await make_printer_worker(p, db, opcua_client) for p in printers]
 
     return AppContext(
         db=db, session=session, opcua_client=opcua_client, printer_workers=workers

--- a/tests/config/test_loaders.py
+++ b/tests/config/test_loaders.py
@@ -31,33 +31,33 @@ def test_is_mocking(app_config):
     assert not is_mocking("opc.tcp://127.0.0.1:4840")
 
 
-@pytest.mark.asyncio
-async def test_make_mock_opcua_client():
+def test_make_mock_opcua_client():
     url = "mock.opc.tcp://127.0.0.1:4840"
-    client = await make_opcua_client(url)
+    client = make_opcua_client(url)
     assert isinstance(client, MockOpcuaClient)
     assert client.url == url
 
 
-@pytest.mark.asyncio
-async def test_make_opcua_client():
+def test_make_opcua_client():
     url = "opc.tcp://127.0.0.1:4840"
-    client = await make_opcua_client(url)
+    client = make_opcua_client(url)
     assert isinstance(client, OpcuaClient)
     assert client.url == url
 
 
-def test_make_mock_octo_client():
+@pytest.mark.asyncio
+async def test_make_mock_octo_client():
     url, api_key = "mock://localhost:5000", "foobar"
-    client = make_octo_client(url, api_key)
+    client = await make_octo_client(url, api_key)
     assert isinstance(client, MockOctoClient)
     assert client.url == url
     assert client.api_key == api_key
 
 
-def test_make_octo_client():
+@pytest.mark.asyncio
+async def test_make_octo_client():
     url, api_key = "http://localhost:5000", "foobar"
-    client = make_octo_client(url, api_key)
+    client = await make_octo_client(url, api_key)
     assert isinstance(client, OctoRestClient)
     assert client.url == url
     assert client.api_key == api_key


### PR DESCRIPTION
`aiohttp.ClientSession` must be created in async functions. This PR only does a quick fix, but I think a better design is needed.