### PR TITLE
feat: stream printer camera by id or opcua name

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -4,10 +4,10 @@ from contextlib import asynccontextmanager
 from fastapi import APIRouter, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from .routers import jobs, printers
 from db import database
 from service import PrinterService, opcua_service
 from worker.manager import start_new_printer_worker
+from .routers import jobs, printers
 
 
 @asynccontextmanager


### PR DESCRIPTION
Related to [this issue](https://github.com/monash-automation/mes/issues/2).

In previous design, the local IP of cameras (e.g. `172.32.1.90`) is returned directly to clients. The clients render the camera stream in a image tag.

```html
<img src="172.32.1.90/?action=stream" >
```

This won't work if the printing service is accessed outside the lab because the local IP cannot be resolved.

To solve this problem, the printing server need to forward the streaming request from browsers to the camera and forward the streaming response from the camera to the browsers.