### PR TITLE
camera stream: use response headers from original response

### DIFF
--- a/src/app/routers/printers.py
+++ b/src/app/routers/printers.py
@@ -57,9 +57,7 @@ class HttpPrinterService(PrinterService):
 
         return StreamingResponse(
             content=resp.aiter_bytes(),
-            headers={
-                "Content-Type": "multipart/x-mixed-replace;boundary=boundarydonotcross"
-            },
+            headers=resp.headers,
             background=BackgroundTask(resp.aclose),
         )
 


### PR DESCRIPTION
Related to [#2](https://github.com/monash-automation/mes/issues/2).

As titled